### PR TITLE
Add support to skip key encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@ grunt-cert
 ==========
 Generates private keys and certificates in a Grunt task.
 
-##Requirements
+## Requirements
 - openssl installed
 - grunt installed
 
 
-##Example Grunt configuration
+## Example Grunt configuration
 ```
 module.exports = function(grunt) {
     grunt.initConfig({
@@ -23,6 +23,7 @@ module.exports = function(grunt) {
                 }
             },
             cert: {
+                encryptKey: true,
                 mode: {
                     type: 'cert',
                     keySize: 4096


### PR DESCRIPTION
In some cases it is not desirable to encrypt the private key when
generating a certificate. For example, I want to use this module to
generate a test certificate for Cockpit, which does not use encrypted
keys.

To accomodate this I add the new option `encryptKey` which is set to
`true` by default to ensure backward compatability. As this value is
a boolean I could not use `Object.assign` to assign this value, but
normal old-fashioned assignment works fine.